### PR TITLE
feat: Improve color picker icon visibility

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -141,7 +141,11 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title, style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
         actions: <Widget>[
           IconButton(
-            icon: const Icon(Icons.color_lens),
+            icon: Icon(
+              Icons.color_lens,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            iconSize: 30.0,
             onPressed: _showColorPickerDialog,
             tooltip: 'Change Theme Color',
           ),

--- a/test/widget/my_app_test.dart
+++ b/test/widget/my_app_test.dart
@@ -12,4 +12,31 @@ void main() {
     // Verify that a Button with the text "Push Me" is present.
     expect(find.widgetWithText(ElevatedButton, 'Coming Soon'), findsOneWidget);
   });
+
+  testWidgets('AppBar IconButton has correct iconSize and color', (WidgetTester tester) async {
+    // Build the app and trigger a frame.
+    await tester.pumpWidget(const MyApp());
+
+    // Find the IconButton by its icon.
+    final iconButtonFinder = find.widgetWithIcon(IconButton, Icons.color_lens);
+    expect(iconButtonFinder, findsOneWidget);
+
+    // Get the IconButton widget.
+    final IconButton iconButton = tester.widget(iconButtonFinder);
+
+    // Verify the iconSize.
+    expect(iconButton.iconSize, 30.0);
+
+    // Verify the icon color.
+    // We need the context from the AppBar to correctly get the theme color.
+    final appBarFinder = find.byType(AppBar);
+    expect(appBarFinder, findsOneWidget);
+    final BuildContext appBarContext = tester.element(appBarFinder);
+
+    // Get the Icon widget from the IconButton.
+    final Icon iconWidget = iconButton.icon as Icon;
+
+    // Verify the color of the Icon.
+    expect(iconWidget.color, Theme.of(appBarContext).colorScheme.onPrimary);
+  });
 }


### PR DESCRIPTION
Increased the size of the color picker icon in the AppBar to 30.0. Set the icon color to use the theme's onPrimary color, ensuring better contrast with the AppBar's primary background color.

A widget test has been added to verify the icon's size and color, ensuring these visibility enhancements are maintained.